### PR TITLE
3 simple fixes

### DIFF
--- a/src/json.c
+++ b/src/json.c
@@ -1086,6 +1086,7 @@ DEFUN ("json-rpc-connection", Fjson_rpc_connection, Sjson_rpc_connection, 1, MAN
       /* TODO: mutex_init could fail */
       state->handle = handle;
       state->done = false;
+      state->error_buffer_read = 0;
       SAFE_FREE ();
       return make_user_ptr (json_rpc_state_free, state);
     }

--- a/src/json.c
+++ b/src/json.c
@@ -1288,7 +1288,7 @@ json_rpc_callback (void *arg)
 	  if (!param->done)
 	    {
 	      msg[content_length] = '\0';
-	      param->message = json_loads (msg, JSON_DECODE_ANY, &param->error);
+	      param->message = json_loads (msg, JSON_DECODE_ANY | JSON_ALLOW_NUL, &param->error);
 	      free (msg);
 	    }
 	}

--- a/src/json.c
+++ b/src/json.c
@@ -1085,6 +1085,7 @@ DEFUN ("json-rpc-connection", Fjson_rpc_connection, Sjson_rpc_connection, 1, MAN
       pthread_mutex_init (&state->handle_mx, NULL);
       /* TODO: mutex_init could fail */
       state->handle = handle;
+      state->done = false;
       SAFE_FREE ();
       return make_user_ptr (json_rpc_state_free, state);
     }


### PR DESCRIPTION
these are all one-liners, so while the three fixes are mostly unrelated to each other, I don't think separate PRs make sense. I haven't actually tested this change, since I'm privately using Emacs 29 (with json-rpc plus these three patches applied), but unless the JSON_ALLOW_NUL flag is undefined on Emacs 28 for some reason, I'm pretty sure it should work